### PR TITLE
fix: + "@remotion/media-utils": "^3.0.0",

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"@remotion/bundler": "^3.0.0",
 		"@remotion/cli": "^3.0.0",
 		"@remotion/eslint-config": "^3.0.0",
+		"@remotion/media-utils": "^3.0.0",
 		"@remotion/renderer": "^3.0.0",
 		"eslint": "^8.14.0",
 		"prettier": "^2.6.2",


### PR DESCRIPTION
Won't run without this dependency.

It is in the `yarn.lock` already for some reason.
But I didn't bother updating any of the `.lock` files, since I use pnpm anyway.

cheers :)